### PR TITLE
add warehouse operations to dbt cloud

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -9,12 +9,18 @@ data-paths: ["data"]
 macro-paths: ["macros"]
 
 
+on-run-start:
+    - "{{resume_warehouse(var('resume_warehouse', false), var('warehouse_name'))}}"    
+
 on-run-end: 
+    - "{{suspend_warehouse(var('suspend_warehouse', false), var('warehouse_name'))}}"
     - "grant usage on schema {{target.schema}} to role REPORTER"
     - "grant usage on schema {{target.schema}} to role LOADER"
     
 models:
     post-hook: "grant select on {{this}} to role REPORTER"
+    vars:
+        warehouse_name: 'LOADING'
     
 target-path: "target"  
 clean-targets:

--- a/macros/alter_warehouse.sql
+++ b/macros/alter_warehouse.sql
@@ -1,0 +1,15 @@
+{% macro resume_warehouse(run, warehouse) %}
+    {% if run == true %}
+        alter warehouse {{warehouse}} resume
+    {% else %}
+        select 1 as test
+    {% endif %}
+{% endmacro %}
+
+{% macro suspend_warehouse(run, warehouse) %}
+    {% if run == true %}
+        alter warehouse {{warehouse}} suspend
+    {% else %}
+        select 1 as test
+    {% endif %}
+{% endmacro %}

--- a/models/admin/warehouse_operation.sql
+++ b/models/admin/warehouse_operation.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        materialized = 'incremental',
+        sql_where = 'TRUE'
+    )
+}}
+
+select
+    current_timestamp() as run_at,
+    {{var('resume_warehouse', false)}} as warehouse_resumed,
+    {{var('suspend_warehouse', false)}} as warehouse_suspended,
+    '{{var('warehouse_name')}}' as warehouse_name


### PR DESCRIPTION
## Problem: 
- Stitch is using too many loading credits, even when using anchor time and scheduled runs

## Solution: 
- Manual resume and suspend process for the loading warehouse in snowflake.

## Implementation:
- Create two dbt Cloud jobs. 
  - One resumes the warehouse loading at 8 UTC (Midnight PST)
  - The other suspends the warehouse loading at 9 UTC (1am PST)
- Set auto resume to false on warehouse loading


 