### PR TITLE
Ecommerce Metrics Modeling

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -21,6 +21,13 @@ models:
     post-hook: "grant select on {{this}} to role REPORTER"
     vars:
         warehouse_name: 'LOADING'
+        addresses_table: stg_shopify_customers
+        customers_table: stg_shopify_customers
+        order_items_table: stg_shopify_order_items
+        orders_table: stg_shopify_orders
+        products_table: stg_shopify_products
+        customer_aggregate_on: customer_id
+        customer_join_on: customer_id        
     
 target-path: "target"  
 clean-targets:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -19,16 +19,23 @@ on-run-end:
     
 models:
     post-hook: "grant select on {{this}} to role REPORTER"
+    fishtown_analytics_ecommerce:
+      transform:
+        addresses:
+          enabled: false
+
     vars:
         warehouse_name: 'LOADING'
-        addresses_table: stg_shopify_customers
+        addresses_table: "not using this"
         customers_table: stg_shopify_customers
         order_items_table: stg_shopify_order_items
         orders_table: stg_shopify_orders
         products_table: stg_shopify_products
         customer_aggregate_on: customer_id
-        customer_join_on: customer_id        
-    
+        customer_join_on: customer_id
+               
+    perfect_keto:
+        
 target-path: "target"  
 clean-targets:
     - "target"

--- a/models/staging/shopify/stg_shopify_order_items.sql
+++ b/models/staging/shopify/stg_shopify_order_items.sql
@@ -9,10 +9,12 @@ flattened_items as (
     select
     
         f.value:id::varchar as order_item_id,
+        tags,
         id as order_id,
         order_number,
         nullif(lower(email),'') as email,
         financial_status,
+        created_at,
         f.value:product_id::varchar as product_id,
         f.value:sku::varchar as product_sku,
         f.value:title::varchar as product_title,

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: fishtown-analytics/fishtown_analytics_ecommerce
+    version: 0.1.9


### PR DESCRIPTION
## Sprint 2: Ecommerce Dashboarding/Modeling

### Mode Reports
- Two Ecommerce dashboards have been built in Mode with parameters (time range, time segment) that allow for dynamic analysis. 
- The [ecommerce metrics report](https://modeanalytics.com/perfectketo/reports/cfabd5ed00ac) contains many of the standard KPIs for ecommerce businesses such as Total Revenue, Distinct Customers, Average Time Between Orders and Average Order Value.
- The [cohort analysis report](https://modeanalytics.com/perfectketo/reports/683472561ef0) provides insight into user activity grouped by a customer's first purchase. This dashboard shows User Retention Rate and Average Customer Value.

### Modeling
- This PR implements the [`fishtown_analytics_ecommerce`](https://github.com/fishtown-analytics/ecommerce) package to build the necessary metrics in Mode.

