### PR TITLE
add klayvio clicks base model

### DIFF
--- a/models/staging/klayvio/stg_klayvio_clicks.sql
+++ b/models/staging/klayvio/stg_klayvio_clicks.sql
@@ -1,0 +1,15 @@
+with source as (
+    select * from raw.perfect_keto_klaviyo.click
+),
+
+renamed as (
+    
+    select
+        datetime::timestamp as date_time,
+        event_properties:"Campaign Name"::string as campaign_name,
+        person:email::string as email,
+        *
+    from source
+)
+
+select * from renamed    


### PR DESCRIPTION
### This PR adds a Klayvio Clicks Base Model
- This base model adds some columnar logic
  - `datetime` casted as timestamp
  - `campaing_name` extracted from event_properties object
  - `email` extracted from person object