### PR TITLE
Fact Orders

### DIFF
--- a/models/marts/attribution/order_attribution.sql
+++ b/models/marts/attribution/order_attribution.sql
@@ -24,7 +24,7 @@ with sessions as (
 
 orders as (
 
-    select * from {{ ref('orders_xf') }}
+    select * from {{ ref('fct_orders') }}
     where customer_id is not null
 
 ),

--- a/models/marts/ecommerce/fct_orders.sql
+++ b/models/marts/ecommerce/fct_orders.sql
@@ -1,0 +1,36 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+with 
+orders as (
+    select * from {{ ref('orders_xf') }}
+),
+
+transactions as (
+    select 
+        *,
+        row_number() over (partition by order_id order by 
+            created_at desc) as most_recent_transaction
+    from {{ ref('stg_shopify_transactions') }}
+),
+
+recent_transactions as (
+    select * from transactions
+    where most_recent_transaction = 1
+),
+
+joined as (
+    
+    select 
+        orders.*,
+        recent_transactions.created_at as paid_at,
+        recent_transactions.gateway as payment_method
+    from orders
+    left join recent_transactions
+        using (order_id)
+)
+
+select * from joined

--- a/models/marts/ecommerce/fct_orders.sql
+++ b/models/marts/ecommerce/fct_orders.sql
@@ -10,26 +10,27 @@ orders as (
 ),
 
 transactions as (
-    select 
-        *,
-        row_number() over (partition by order_id order by 
-            created_at desc) as most_recent_transaction
+    select distinct
+        
+        order_id,
+         
+        last_value(created_at) over (partition by order_id order by 
+            created_at) as paid_at,
+            
+        last_value(gateway) over (partition by order_id order by 
+            created_at) as payment_method
+            
     from {{ ref('stg_shopify_transactions') }}
-),
-
-recent_transactions as (
-    select * from transactions
-    where most_recent_transaction = 1
 ),
 
 joined as (
     
     select 
         orders.*,
-        recent_transactions.created_at as paid_at,
-        recent_transactions.gateway as payment_method
+        transactions.paid_at,
+        transactions.payment_method
     from orders
-    left join recent_transactions
+    left join transactions
         using (order_id)
 )
 

--- a/models/marts/ecommerce/schema.yml
+++ b/models/marts/ecommerce/schema.yml
@@ -1,0 +1,11 @@
+
+version: 2
+
+models:
+    - name: fct_orders
+      
+      columns:
+          - name: order_id
+            tests:
+                - not_null
+                - unique

--- a/models/staging/shopify/schema.yml
+++ b/models/staging/shopify/schema.yml
@@ -35,3 +35,10 @@ models:
             tests:
                 - unique
                 - not_null
+                
+    - name: stg_shopify_transactions
+      columns:
+          - name: id
+            tests:
+                - unique
+                - not_null

--- a/models/staging/shopify/stg_shopify_orders.sql
+++ b/models/staging/shopify/stg_shopify_orders.sql
@@ -34,6 +34,7 @@ renamed as (
         number as "number",
         order_number,
         currency,
+        discount_codes[0]:code::string as discount_code,
         presentment_currency,
         financial_status,
         case when financial_status in ('paid', 'partially_paid', 'partially_refunded')
@@ -45,6 +46,7 @@ renamed as (
         processing_method,
         total_tip_received,
         total_weight,
+        shipping_lines[0]:title::string as shipping_method,
         total_discounts,
         subtotal_price,
         total_line_items_price,
@@ -76,6 +78,7 @@ renamed as (
         
         -- dates
         created_at,
+        to_timestamp(fulfillments[0]:created_at::string, 'yyyy-mm-ddThh24:mi:ssZ') as fulfilled_at,
         processed_at,
         closed_at,
         updated_at,

--- a/models/staging/shopify/stg_shopify_transactions.sql
+++ b/models/staging/shopify/stg_shopify_transactions.sql
@@ -1,0 +1,35 @@
+with transactions_base as (
+    select * from raw.perfect_keto_shopify.transactions
+),
+
+renamed_transactions as (
+    select
+        admin_graphql_api_id,
+        amount,
+        authorization,
+        to_timestamp(created_at, 'yyyy-mm-ddThh24:mi:ss-TZH:TZM') as created_at,
+        currency,
+        error_code,
+        gateway,
+        id,
+        kind,
+        message,
+        order_id,
+        parent_id,
+        payment_details,
+        receipt,
+        source_name,
+        status,
+        test,
+        _sdc_batched_at,
+        _sdc_extracted_at,
+        _sdc_received_at,
+        _sdc_sequence,
+        _sdc_table_version,
+        location_id,
+        device_id,
+        user_id
+    from transactions_base
+)
+
+select * from renamed_transactions


### PR DESCRIPTION
## This PR Creates a Fact Orders Table

### Fact Orders
- Takes the `orders_xf` table (created by the fishtown ecommerce package) and joins relevant transaction data.
- Maintains the order_id granularity.

### Base Models
- stg_shopify_orders
  - added unnested discount, shipping, and fulfillment information
- stg_shopify_transactions
  - created this view