### PR TITLE
convert snowplow and shopify_orders to PST

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -51,7 +51,7 @@ models:
 
     snowplow:
         vars:
-            snowplow:timezone: 'America/New_York'
+            snowplow:timezone: 'America/Los_Angeles'
             snowplow:page_ping_frequency: 10
             snowplow:events: "{{ ref('stg_events') }}"
             snowplow:context:web_page: "{{ ref('stg_web_page_context')}}"

--- a/models/staging/shopify/stg_shopify_orders.sql
+++ b/models/staging/shopify/stg_shopify_orders.sql
@@ -77,12 +77,15 @@ renamed as (
         nullif(lower(billing_address:zip::varchar), '') as billing_zip_code,
         
         -- dates
-        created_at,
-        to_timestamp(fulfillments[0]:created_at::string, 'yyyy-mm-ddThh24:mi:ssZ') as fulfilled_at,
-        processed_at,
-        closed_at,
-        updated_at,
-        cancelled_at,
+        convert_timezone('UTC','America/Los_Angeles',created_at::timestamp_ntz) as created_at,
+        convert_timezone('UTC','America/Los_Angeles',
+            to_timestamp(fulfillments[0]:created_at::string,
+                 'yyyy-mm-ddThh24:mi:ssZ')::timestamp_ntz) as fulfilled_at,
+        convert_timezone('UTC','America/Los_Angeles',processed_at::timestamp_ntz) as processed_at,
+        convert_timezone('UTC','America/Los_Angeles',closed_at::timestamp_ntz) as closed_at,
+        convert_timezone('UTC','America/Los_Angeles',updated_at::timestamp_ntz) as updated_at,
+        convert_timezone('UTC','America/Los_Angeles',cancelled_at::timestamp_ntz) as cancelled_at,
+
         cancel_reason,
         
         -- nested


### PR DESCRIPTION
### Fix Timezone Issue Between Shopify and Snowplow
- This PR changes the timezone for both Shopify and Snowplow to PST
- This was discovered through the order attribution audit
  - Some Snowplow events were occurring _after_ the corresponding order was created
  - These orders were being filtered out from the where condition
  - `where sessions.session_start <= orders.created_at`