### PR TITLE
add stg_amazon models for raw data

### DIFF
--- a/models/staging/amazon/stg_amazon_mws.sql
+++ b/models/staging/amazon/stg_amazon_mws.sql
@@ -1,0 +1,13 @@
+with source as (
+    select
+        convert_timezone('America/Los_Angeles', purchasedate)::date as day,
+        item.value:SellerSKU::string as sku,
+        item.value:ASIN::string as asin,
+        item.value:ItemPrice:Amount::float as price,
+        item.value:ProductInfo:NumberOfItems::int as units_ordered,
+        orderstatus
+    from raw.perfect_keto_amazon_mws.orders,
+    lateral flatten (input => orderitems) item
+)
+
+select * from source

--- a/models/staging/amazon/stg_amazon_sponsored_brands.sql
+++ b/models/staging/amazon/stg_amazon_sponsored_brands.sql
@@ -1,0 +1,10 @@
+with source as (
+    select 
+        day::date as day,
+        campaignname,
+        cost,
+        attributedSales14d
+    from raw.perfect_keto_amazon_advertising.sponsored_brands_report_campaigns
+)
+
+select * from source 

--- a/models/staging/amazon/stg_amazon_sponsored_products.sql
+++ b/models/staging/amazon/stg_amazon_sponsored_products.sql
@@ -1,0 +1,13 @@
+with source as (
+    select
+    	day::date as day,
+        sku,
+        asin,
+        cost as cost,
+        attributedSales7d,
+        attributedUnitsOrdered7d
+    from raw.perfect_keto_amazon_advertising.sponsored_products_report_product_ads
+    left join raw.perfect_keto_amazon_advertising.product_ads using (adid)
+)
+
+select * from source


### PR DESCRIPTION
### This PR adds an Amazon order data model

`stg_amazon_sponsored_products`:

- `day`
- `sku`
- `asin`
- `cost`
- `attributedSales7d`
- `attributedUnitsOrdered7d`

`stg_amazon_sponsored_brands`:

- `day`
- `campaignname`
- `cost`
- `attributedSales14d`

`stg_amazon_mws`:

- `day`
- `sku`
- `asin`
- `price`
- `units_ordered`
- `orderstatus`
