### PR TITLE
update timezone setting in snowplow dbt_project.yml to PST

### DIFF
--- a/dbt_modules/snowplow/dbt_project.yml
+++ b/dbt_modules/snowplow/dbt_project.yml
@@ -1,0 +1,32 @@
+#settings specifically for this models directory
+#config other dbt settings within ~/.dbt/profiles.yml
+name: 'snowplow'
+version: '0.0.1'
+
+source-paths: ["models"]
+target-path: "target"
+clean-targets: ["target"]
+test-paths: ["test"]
+analysis-paths: ["analysis"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+
+models:
+  snowplow:
+    base:
+      materialized: ephemeral
+      optional:
+        enabled: false
+    page_views:
+      optional:
+        enabled: false
+
+    vars:
+      #'snowplow:events': TABLE OR {{ REF() }}
+      #'snowplow:context:web_page': TABLE OR {{ REF() }}
+      #'snowplow:context:performance_timing': TABLE OR {{ REF() }} or FALSE
+      #'snowplow:context:useragent': TABLE OR {{ REF() }} or FALSE
+      'snowplow:timezone': 'America/Los_Angeles'
+      'snowplow:page_ping_frequency': 10
+      'snowplow:app_ids': []
+      'snowplow:pass_through_columns': []


### PR DESCRIPTION
## This PR will update timezone setting in snowplow dbt_project.yml to PST

The default timezone is New York / EST and may be a potential issue with snowplow timestamps not aligning with Shopify orders. 