### PR TITLE
fixes model references from last pr

### DIFF
--- a/models/marts/amazon/fct_amazon_main_metrics.sql
+++ b/models/marts/amazon/fct_amazon_main_metrics.sql
@@ -2,8 +2,8 @@ with skus as (
     select
         coalesce(m.sku,s.sku) as sku,
         coalesce(m.asin,s.asin) as asin
-    from analytics.dbt_faisal.stg_amazon_mws m
-    full outer join analytics.dbt_faisal.stg_amazon_sponsored_products s on m.sku = s.sku
+    from {{ ref('stg_amazon_mws') }} m
+    full outer join {{ ref('stg_amazon_sponsored_products') }} s on m.sku = s.sku
 ),
 
 amazon_main_metrics as (
@@ -19,8 +19,8 @@ amazon_main_metrics as (
         round(zeroifnull(m."Y7 Units"+sp."Y7 Units"),2) as "Y7 Units",
         round(zeroifnull(m."Y30 Units"+sp."Y30 Units"),2) as "Y30 Units"
     from skus s
-    full join analytics.dbt_faisal.fct_amazon_mws_metrics m on s.sku = m.sku
-    full join analytics.dbt_faisal.fct_amazon_sp_metrics sp on s.sku = sp.sku
+    full join {{ ref('fct_amazon_mws_metrics') }} m on s.sku = m.sku
+    full join {{ ref('fct_amazon_sp_metrics') }} sp on s.sku = sp.sku
     order by round(zeroifnull(m."Y30 Units"+sp."Y30 Units"),2) desc nulls last
 )
 

--- a/models/marts/amazon/fct_amazon_mws_metrics.sql
+++ b/models/marts/amazon/fct_amazon_mws_metrics.sql
@@ -10,7 +10,7 @@ with mws_orders as (
         sum(amazon_referral) as amazon_referral,
         sum(amazon_fba_fee) as amazon_fba_fee,
         sum(contribution_margin) as contribution_margin
-    from analytics.dbt_faisal.stg_amazon_mws
+    from {{ ref('stg_amazon_mws') }}
     where orderstatus != 'Canceled'
     group by 1,2,3
 ),

--- a/models/marts/amazon/fct_amazon_sp_metrics.sql
+++ b/models/marts/amazon/fct_amazon_sp_metrics.sql
@@ -10,7 +10,7 @@ with orders as (
         sum(amazon_fba_fee) as amazon_fba_fee,
         sum(contribution_margin) as contribution_margin,
         sum(attributedunitsordered7d) as attributedUnitsOrdered7d
-    from analytics.dbt_faisal.stg_amazon_sponsored_products
+    from analytics.stg_amazon_sponsored_products
     group by 1,2,3
     order by 1 desc
 ),


### PR DESCRIPTION
This PR fixes a model references error from last PR commit. 

The previous commit used dbt_faisal as a reference instead of production.