### PR TITLE
add shopify financial models

### DIFF
--- a/models/marts/financials/fct_shopify_daily.sql
+++ b/models/marts/financials/fct_shopify_daily.sql
@@ -1,0 +1,194 @@
+with gift_cards as (
+
+    select *
+    from {{ ref('stg_shopify_order_items') }}
+    where gift_card = true 
+
+),
+
+orders as (
+
+    select o.*    
+    from {{ ref('orders_xf') }} o
+    where 
+        not exists (
+        
+            select * from gift_cards g where o.order_id = g.order_id
+        
+        )
+    
+),
+
+refund_items as (
+
+    select * from {{ ref('stg_shopify_refund_items') }}
+
+),
+
+order_adjustments as (
+
+    select * from {{ ref('stg_shopify_refund_order_adjustments') }}
+
+),
+
+refund_calc as (
+
+    select
+        refund_processed_at::date as date,
+        order_id,
+        order_item_id,
+        product_title,
+        order_item_price,
+        order_item_subtotal,
+        quantity,
+        order_item_price*quantity*-1 as gross_returns,
+        discount_amount,
+        tax_amount as tax_amount
+    from refund_items 
+
+),
+
+adjustments_calc as (
+
+    select 
+        refund_processed_at::date as date,
+        order_id,
+        order_adjustments as gross_returns,
+        case when kind = 'shipping_refund' then order_adjustments else 0 end as shipping_amount
+    from order_adjustments
+
+),
+
+refund_joined as (
+
+    select 
+        date,
+        order_id,
+        order_item_id,
+        product_title,
+        order_item_price,
+        quantity,
+        gross_returns,
+        discount_amount,
+        tax_amount,
+        0 as shipping_amount
+    from refund_calc
+    union all 
+    select 
+        date,
+        order_id,
+        null as order_item_id,
+        null as product_title,
+        null as order_item_price,
+        0 as quantity,
+        gross_returns,
+        0 as discount_amount,
+        0 as tax_amount,
+        shipping_amount
+    from adjustments_calc
+
+),
+
+refund_final as (
+
+    select
+        date_trunc(day,date) as day,
+        sum(gross_returns) as gross_returns,
+        sum(discount_amount) as discount_returned,
+        sum(gross_returns)+sum(discount_amount) as net_returns,
+        sum(tax_amount) as tax_returned,
+        sum(shipping_amount) as shipping_returned,
+        sum(gross_returns)+sum(discount_amount)+sum(tax_amount)+sum(shipping_amount) as total_returns
+    from refund_joined 
+    group by 1
+    
+),
+
+orders_calc as (
+
+    select 
+        date_trunc(day,created_at) as day,
+        count(distinct order_id) as orders,
+        sum(total_line_items_price) as order_gross,
+        sum(total_discounts*-1) as total_discounts,
+        sum(total_tax) as order_tax_net,
+        sum(total_shipping_cost) as order_shipping_gross,
+        count(case when tags ilike '%subscription%' then 1 else null end) as subscription_orders, 
+        count(case when tags not ilike '%subscription%' then 1 else null end) as one_time_orders, 
+        count(distinct customer_id) as unique_customers, 
+        count(case when new_vs_repeat = 'new' then 1 else null end) as first_time_customers, 
+        count(case when new_vs_repeat = 'repeat' then 1 else null end) as repeat_customers 
+    from orders 
+    group by 1
+    order by 1 desc 
+    
+),
+
+quantity as (
+
+    select 
+        date_trunc(day,o.created_at) as day,
+        sum(quantity) as total_units
+    from {{ ref('stg_shopify_orders') }} o 
+    join {{ ref('stg_shopify_order_items') }} oi on o.order_id = oi.order_id
+    group by 1
+
+),
+
+channels as (
+    select 
+        date_trunc(day,created_at) as order_day,
+        case when tags ilike '%wholesale%' then 'Wholesale'
+        when tags ilike '%subscription%' then 'Recharge'
+            else 'Online Store' end as channel,
+        sum(total_line_items_price) as order_gross,
+        sum(total_discounts) as total_discounts,
+        sum(total_shipping_cost) as order_shipping_gross,
+        sum(total_line_items_price) - sum(total_discounts) + sum(total_shipping_cost) as total_net
+    from orders 
+    group by 1,2
+    order by 1 desc, 6 desc
+),
+
+channels2 as (
+    select 
+        order_day,
+        case when channel = 'Online Store' then total_net end as "Online Store Rev",
+        case when channel = 'Recharge' then total_net end as "Recharge Rev",
+        case when channel = 'Wholesale' then total_net end as "Wholesale Rev"
+    from channels
+    order by 1 desc
+),
+
+final as (
+
+    select 
+        o.day,
+        o.orders,
+        q.total_units, 
+        o.order_gross,
+        o.total_discounts,
+        r.net_returns as total_refunds,
+        o.order_gross+o.total_discounts+r.net_returns as total_net,
+        o.order_shipping_gross+r.shipping_returned as order_shipping_net,
+        o.order_tax_net+r.tax_returned as order_tax_net,
+        o.subscription_orders,
+        o.one_time_orders,
+        o.unique_customers,
+        o.first_time_customers,
+        o.repeat_customers
+    from orders_calc o 
+    left join refund_final r on o.day = r.day
+    left join quantity q on o.day = q.day
+
+)
+
+select 
+    f.*,
+    sum(ch."Online Store Rev") as "Online Store Rev",
+    sum(ch."Recharge Rev") as "Recharge Rev",
+    sum(ch."Wholesale Rev") as "Wholesale Rev"
+from final f
+left join channels2 ch on f.day = ch.order_day
+group by 1,2,3,4,5,6,7,8,9,10,11,12,13,14
+order by 1 asc

--- a/models/marts/financials/fct_shopify_monthly.sql
+++ b/models/marts/financials/fct_shopify_monthly.sql
@@ -1,0 +1,194 @@
+with gift_cards as (
+
+    select *
+    from {{ ref('stg_shopify_order_items') }}
+    where gift_card = true 
+
+),
+
+orders as (
+
+    select o.*    
+    from {{ ref('orders_xf') }} o
+    where 
+        not exists (
+        
+            select * from gift_cards g where o.order_id = g.order_id
+        
+        )
+    
+),
+
+refund_items as (
+
+    select * from {{ ref('stg_shopify_refund_items') }}
+
+),
+
+order_adjustments as (
+
+    select * from {{ ref('stg_shopify_refund_order_adjustments') }}
+
+),
+
+refund_calc as (
+
+    select
+        refund_processed_at::date as date,
+        order_id,
+        order_item_id,
+        product_title,
+        order_item_price,
+        order_item_subtotal,
+        quantity,
+        order_item_price*quantity*-1 as gross_returns,
+        discount_amount,
+        tax_amount as tax_amount
+    from refund_items 
+
+),
+
+adjustments_calc as (
+
+    select 
+        refund_processed_at::date as date,
+        order_id,
+        order_adjustments as gross_returns,
+        case when kind = 'shipping_refund' then order_adjustments else 0 end as shipping_amount
+    from order_adjustments
+
+),
+
+refund_joined as (
+
+    select 
+        date,
+        order_id,
+        order_item_id,
+        product_title,
+        order_item_price,
+        quantity,
+        gross_returns,
+        discount_amount,
+        tax_amount,
+        0 as shipping_amount
+    from refund_calc
+    union all 
+    select 
+        date,
+        order_id,
+        null as order_item_id,
+        null as product_title,
+        null as order_item_price,
+        0 as quantity,
+        gross_returns,
+        0 as discount_amount,
+        0 as tax_amount,
+        shipping_amount
+    from adjustments_calc
+
+),
+
+refund_final as (
+
+    select
+        date_trunc(month,date) as month,
+        sum(gross_returns) as gross_returns,
+        sum(discount_amount) as discount_returned,
+        sum(gross_returns)+sum(discount_amount) as net_returns,
+        sum(tax_amount) as tax_returned,
+        sum(shipping_amount) as shipping_returned,
+        sum(gross_returns)+sum(discount_amount)+sum(tax_amount)+sum(shipping_amount) as total_returns
+    from refund_joined 
+    group by 1
+    
+),
+
+orders_calc as (
+
+    select 
+        date_trunc(month,created_at) as month,
+        count(distinct order_id) as orders,
+        sum(total_line_items_price) as order_gross,
+        sum(total_discounts*-1) as total_discounts,
+        sum(total_tax) as order_tax_net,
+        sum(total_shipping_cost) as order_shipping_gross,
+        count(case when tags ilike '%subscription%' then 1 else null end) as subscription_orders, 
+        count(case when tags not ilike '%subscription%' then 1 else null end) as one_time_orders, 
+        count(distinct customer_id) as unique_customers, 
+        count(case when new_vs_repeat = 'new' then 1 else null end) as first_time_customers, 
+        count(case when new_vs_repeat = 'repeat' then 1 else null end) as repeat_customers 
+    from orders 
+    group by 1
+    order by 1 desc 
+    
+),
+
+quantity as (
+
+    select 
+        date_trunc(month,o.created_at) as month,
+        sum(quantity) as total_units
+    from {{ ref('stg_shopify_orders') }} o 
+    join {{ ref('stg_shopify_order_items') }} oi on o.order_id = oi.order_id
+    group by 1
+
+),
+
+channels as (
+    select 
+        date_trunc(month,created_at) as order_month,
+        case when tags ilike '%wholesale%' then 'Wholesale'
+        when tags ilike '%subscription%' then 'Recharge'
+            else 'Online Store' end as channel,
+        sum(total_line_items_price) as order_gross,
+        sum(total_discounts) as total_discounts,
+        sum(total_shipping_cost) as order_shipping_gross,
+        sum(total_line_items_price) - sum(total_discounts) + sum(total_shipping_cost) as total_net
+    from orders 
+    group by 1,2
+    order by 1 desc, 6 desc
+),
+
+channels2 as (
+    select 
+        order_month,
+        case when channel = 'Online Store' then total_net end as "Online Store Rev",
+        case when channel = 'Recharge' then total_net end as "Recharge Rev",
+        case when channel = 'Wholesale' then total_net end as "Wholesale Rev"
+    from channels
+    order by 1 desc
+),
+
+final as (
+
+    select 
+        o.month,
+        o.orders,
+        q.total_units, 
+        o.order_gross,
+        o.total_discounts,
+        r.net_returns as total_refunds,
+        o.order_gross+o.total_discounts+r.net_returns as total_net,
+        o.order_shipping_gross+r.shipping_returned as order_shipping_net,
+        o.order_tax_net+r.tax_returned as order_tax_net,
+        o.subscription_orders,
+        o.one_time_orders,
+        o.unique_customers,
+        o.first_time_customers,
+        o.repeat_customers
+    from orders_calc o 
+    left join refund_final r on o.month = r.month
+    left join quantity q on o.month = q.month
+
+)
+
+select 
+    f.*,
+    sum(ch."Online Store Rev") as "Online Store Rev",
+    sum(ch."Recharge Rev") as "Recharge Rev",
+    sum(ch."Wholesale Rev") as "Wholesale Rev"
+from final f
+left join channels2 ch on f.month = ch.order_month
+group by 1,2,3,4,5,6,7,8,9,10,11,12,13,14
+order by 1 asc

--- a/models/marts/financials/fct_shopify_monthly_cohort_retention.sql
+++ b/models/marts/financials/fct_shopify_monthly_cohort_retention.sql
@@ -1,0 +1,55 @@
+with customers as (
+
+    select *
+    from {{ ref('orders_xf') }}
+
+), 
+
+second as (
+
+    select 
+        customer_id,
+        created_at as second_order_date,
+        first_order_date,
+        date_trunc(month,first_order_date) as cohort_month,
+        days_from_first_completed_order as days_to_second_purchase,
+        customer_age_days,
+        case when days_from_first_completed_order <= 30 
+            and customer_age_days >= 30 then 1 else 0 end as "repeat_30d_rate",
+        case when days_from_first_completed_order <= 60 
+            and customer_age_days >= 60 then 1 else 0 end as "repeat_60d_rate",
+        case when days_from_first_completed_order <= 90 
+            and customer_age_days >= 88 then 1 else 0 end as "repeat_90d_rate",
+        case when days_from_first_completed_order <= 180 
+            and customer_age_days >= 180 then 1 else 0 end as "repeat_180d_rate",
+        case when days_from_first_completed_order <= 360 
+            and customer_age_days >= 360 then 1 else 0 end as "repeat_360d_rate"
+    from {{ ref('orders_xf') }}
+    where order_seq_number = 2
+    order by customer_id, order_seq_number
+
+), 
+
+cohort_sizes as (
+
+    select 
+      date_trunc(month,first_order_date) as cohort_month,
+      count(distinct customer_id) as cohort_size
+    from {{ ref('orders_xf') }}
+    group by 1
+    order by 1 desc
+
+)
+
+select 
+    s.cohort_month,
+    c.cohort_size,
+    sum("repeat_30d_rate")/c.cohort_size*100 as repeat_30d_rate,
+    sum("repeat_60d_rate")/c.cohort_size*100 as repeat_60d_rate,
+    sum("repeat_90d_rate")/c.cohort_size*100 as repeat_90d_rate,
+    sum("repeat_180d_rate")/c.cohort_size*100 as repeat_180d_rate,
+    sum("repeat_360d_rate")/c.cohort_size*100 as repeat_360d_rate
+from second s
+left join cohort_sizes c on c.cohort_month = s.cohort_month
+group by 1,2
+order by 1 asc

--- a/models/marts/financials/fct_shopify_sku_daily.sql
+++ b/models/marts/financials/fct_shopify_sku_daily.sql
@@ -1,0 +1,72 @@
+with orders as (
+
+    select 
+        o.order_id,
+        o.created_at,
+        product_sku as sku,
+        quantity,
+        coalesce(discount_allocations,0) as discount_allocations,
+        price,
+        price*quantity as gross_item_revenue
+    from {{ ref('stg_shopify_orders') }} o 
+    join {{ ref('stg_shopify_order_items') }} oi on o.order_id = oi.order_id
+    where gift_card = false
+    
+),
+
+refund_items as (
+
+    select
+        refund_processed_at::date as date,
+        sku,
+        order_item_price,
+        order_item_subtotal,
+        quantity,
+        order_item_price*quantity*-1 as gross_returns,
+        discount_amount,
+        tax_amount as tax_amount
+    from {{ ref('stg_shopify_refund_items') }}
+
+),
+
+refund_calc as (
+
+    select 
+        date_trunc(day,date) as day,
+        sku,
+        sum(quantity) as units_returned,
+        sum(gross_returns) as returns 
+    from refund_items 
+    group by 1,2
+
+),
+
+orders_calc as (
+
+    select 
+        date_trunc(day,created_at) as day,
+        sku,
+        sum(quantity) as total_units,
+        sum(gross_item_revenue) as gross_item_revenue,
+        sum(discount_allocations) as discounts
+    from orders 
+    group by 1,2
+    order by 4 asc  
+
+),
+
+final as (
+
+    select 
+        o.day,
+        o.sku,
+        o.gross_item_revenue,
+        o.gross_item_revenue-o.discounts+r.returns as net_item_revenue,
+        o.total_units-r.units_returned as total_units
+    from orders_calc o
+    left join refund_calc r on o.day = r.day and o.sku = r.sku
+
+)
+
+select * from final 
+order by 1 asc, 2 asc

--- a/models/marts/financials/fct_shopify_sku_monthly.sql
+++ b/models/marts/financials/fct_shopify_sku_monthly.sql
@@ -1,0 +1,72 @@
+with orders as (
+
+    select 
+        o.order_id,
+        o.created_at,
+        product_sku as sku,
+        quantity,
+        coalesce(discount_allocations,0) as discount_allocations,
+        price,
+        price*quantity as gross_item_revenue
+    from {{ ref('stg_shopify_orders') }} o 
+    join {{ ref('stg_shopify_order_items') }} oi on o.order_id = oi.order_id
+    where gift_card = false
+    
+),
+
+refund_items as (
+
+    select
+        refund_processed_at::date as date,
+        sku,
+        order_item_price,
+        order_item_subtotal,
+        quantity,
+        order_item_price*quantity*-1 as gross_returns,
+        discount_amount,
+        tax_amount as tax_amount
+    from {{ ref('stg_shopify_refund_items') }} 
+
+),
+
+refund_calc as (
+
+    select 
+        date_trunc(month,date) as month,
+        sku,
+        sum(quantity) as units_returned,
+        sum(gross_returns) as returns 
+    from refund_items 
+    group by 1,2
+
+),
+
+orders_calc as (
+
+    select 
+        date_trunc(month,created_at) as month,
+        sku,
+        sum(quantity) as total_units,
+        sum(gross_item_revenue) as gross_item_revenue,
+        sum(discount_allocations) as discounts
+    from orders 
+    group by 1,2
+    order by 4 asc  
+
+),
+
+final as (
+
+    select 
+        o.month,
+        o.sku,
+        o.gross_item_revenue,
+        o.gross_item_revenue-o.discounts+r.returns as net_item_revenue,
+        o.total_units-r.units_returned as total_units
+    from orders_calc o
+    left join refund_calc r on o.month = r.month and o.sku = r.sku
+
+)
+
+select * from final 
+order by 1 asc, 2 asc

--- a/models/marts/financials/fct_shopify_sku_variant_monthly.sql
+++ b/models/marts/financials/fct_shopify_sku_variant_monthly.sql
@@ -1,0 +1,77 @@
+with orders as (
+
+    select 
+        o.order_id,
+        o.created_at,
+        product_sku as sku,
+        variant_title,
+        quantity,
+        coalesce(discount_allocations,0) as discount_allocations,
+        price,
+        price*quantity as gross_item_revenue
+    from {{ ref('stg_shopify_orders') }} o 
+    join {{ ref('stg_shopify_order_items') }} oi on o.order_id = oi.order_id
+    where gift_card = false
+    
+),
+
+refund_items as (
+
+    select
+        refund_processed_at::date as date,
+        variant_title,
+        sku,
+        order_item_price,
+        order_item_subtotal,
+        quantity,
+        order_item_price*quantity*-1 as gross_returns,
+        discount_amount,
+        tax_amount as tax_amount
+    from {{ ref('stg_shopify_refund_items') }}
+
+),
+
+refund_calc as (
+
+    select 
+        date_trunc(month,date) as month,
+        variant_title,
+        sku,
+        sum(quantity) as units_returned,
+        sum(gross_returns) as returns 
+    from refund_items 
+    group by 1,2,3
+
+),
+
+orders_calc as (
+
+    select 
+        date_trunc(month,created_at) as month,
+        variant_title,
+        sku,
+        sum(quantity) as total_units,
+        sum(gross_item_revenue) as gross_item_revenue,
+        sum(discount_allocations) as discounts
+    from orders 
+    group by 1,2,3
+    order by 4 asc  
+
+),
+
+final as (
+
+    select 
+        o.month,
+        o.variant_title,
+        o.sku,
+        o.gross_item_revenue,
+        o.gross_item_revenue-o.discounts+r.returns as net_item_revenue,
+        o.total_units-r.units_returned as total_units
+    from orders_calc o
+    left join refund_calc r on o.month = r.month and o.variant_title = r.variant_title and o.sku = r.sku
+
+)
+
+select * from final 
+order by 1 asc, 2 asc

--- a/models/marts/financials/fct_shopify_weekly.sql
+++ b/models/marts/financials/fct_shopify_weekly.sql
@@ -1,0 +1,194 @@
+with gift_cards as (
+
+    select *
+    from {{ ref('stg_shopify_order_items') }}
+    where gift_card = true 
+
+),
+
+orders as (
+
+    select o.*    
+    from {{ ref('orders_xf') }} o
+    where 
+        not exists (
+        
+            select * from gift_cards g where o.order_id = g.order_id
+        
+        )
+    
+),
+
+refund_items as (
+
+    select * from {{ ref('stg_shopify_refund_items') }}
+
+),
+
+order_adjustments as (
+
+    select * from {{ ref('stg_shopify_refund_order_adjustments') }}
+
+),
+
+refund_calc as (
+
+    select
+        refund_processed_at::date as date,
+        order_id,
+        order_item_id,
+        product_title,
+        order_item_price,
+        order_item_subtotal,
+        quantity,
+        order_item_price*quantity*-1 as gross_returns,
+        discount_amount,
+        tax_amount as tax_amount
+    from refund_items 
+
+),
+
+adjustments_calc as (
+
+    select 
+        refund_processed_at::date as date,
+        order_id,
+        order_adjustments as gross_returns,
+        case when kind = 'shipping_refund' then order_adjustments else 0 end as shipping_amount
+    from order_adjustments
+
+),
+
+refund_joined as (
+
+    select 
+        date,
+        order_id,
+        order_item_id,
+        product_title,
+        order_item_price,
+        quantity,
+        gross_returns,
+        discount_amount,
+        tax_amount,
+        0 as shipping_amount
+    from refund_calc
+    union all 
+    select 
+        date,
+        order_id,
+        null as order_item_id,
+        null as product_title,
+        null as order_item_price,
+        0 as quantity,
+        gross_returns,
+        0 as discount_amount,
+        0 as tax_amount,
+        shipping_amount
+    from adjustments_calc
+
+),
+
+refund_final as (
+
+    select
+        date_trunc(week,date) as week,
+        sum(gross_returns) as gross_returns,
+        sum(discount_amount) as discount_returned,
+        sum(gross_returns)+sum(discount_amount) as net_returns,
+        sum(tax_amount) as tax_returned,
+        sum(shipping_amount) as shipping_returned,
+        sum(gross_returns)+sum(discount_amount)+sum(tax_amount)+sum(shipping_amount) as total_returns
+    from refund_joined 
+    group by 1
+    
+),
+
+orders_calc as (
+
+    select 
+        date_trunc(week,created_at) as week,
+        count(distinct order_id) as orders,
+        sum(total_line_items_price) as order_gross,
+        sum(total_discounts*-1) as total_discounts,
+        sum(total_tax) as order_tax_net,
+        sum(total_shipping_cost) as order_shipping_gross,
+        count(case when tags ilike '%subscription%' then 1 else null end) as subscription_orders, 
+        count(case when tags not ilike '%subscription%' then 1 else null end) as one_time_orders, 
+        count(distinct customer_id) as unique_customers, 
+        count(case when new_vs_repeat = 'new' then 1 else null end) as first_time_customers, 
+        count(case when new_vs_repeat = 'repeat' then 1 else null end) as repeat_customers 
+    from orders 
+    group by 1
+    order by 1 desc 
+    
+),
+
+quantity as (
+
+    select 
+        date_trunc(week,o.created_at) as week,
+        sum(quantity) as total_units
+    from {{ ref('stg_shopify_orders') }} o 
+    join {{ ref('stg_shopify_order_items') }} oi on o.order_id = oi.order_id
+    group by 1
+
+),
+
+channels as (
+    select 
+        date_trunc(week,created_at) as order_week,
+        case when tags ilike '%wholesale%' then 'Wholesale'
+        when tags ilike '%subscription%' then 'Recharge'
+            else 'Online Store' end as channel,
+        sum(total_line_items_price) as order_gross,
+        sum(total_discounts) as total_discounts,
+        sum(total_shipping_cost) as order_shipping_gross,
+        sum(total_line_items_price) - sum(total_discounts) + sum(total_shipping_cost) as total_net
+    from orders 
+    group by 1,2
+    order by 1 desc, 6 desc
+),
+
+channels2 as (
+    select 
+        order_week,
+        case when channel = 'Online Store' then total_net end as "Online Store Rev",
+        case when channel = 'Recharge' then total_net end as "Recharge Rev",
+        case when channel = 'Wholesale' then total_net end as "Wholesale Rev"
+    from channels
+    order by 1 desc
+),
+
+final as (
+
+    select 
+        o.week,
+        o.orders,
+        q.total_units, 
+        o.order_gross,
+        o.total_discounts,
+        r.net_returns as total_refunds,
+        o.order_gross+o.total_discounts+r.net_returns as total_net,
+        o.order_shipping_gross+r.shipping_returned as order_shipping_net,
+        o.order_tax_net+r.tax_returned as order_tax_net,
+        o.subscription_orders,
+        o.one_time_orders,
+        o.unique_customers,
+        o.first_time_customers,
+        o.repeat_customers
+    from orders_calc o 
+    left join refund_final r on o.week = r.week
+    left join quantity q on o.week = q.week
+
+)
+
+select 
+    f.*,
+    sum(ch."Online Store Rev") as "Online Store Rev",
+    sum(ch."Recharge Rev") as "Recharge Rev",
+    sum(ch."Wholesale Rev") as "Wholesale Rev"
+from final f
+left join channels2 ch on f.week = ch.order_week
+group by 1,2,3,4,5,6,7,8,9,10,11,12,13,14
+order by 1 asc

--- a/models/marts/financials/fct_shopify_weekly_cohort_retention.sql
+++ b/models/marts/financials/fct_shopify_weekly_cohort_retention.sql
@@ -1,0 +1,58 @@
+with customers as (
+
+    select *
+    from {{ ref('orders_xf') }}
+    
+), 
+
+second as (
+
+    select 
+        customer_id,
+        created_at as second_order_date,
+        first_order_date,
+        date_trunc(week,first_order_date) as cohort_week,
+        days_from_first_completed_order as days_to_second_purchase,
+        customer_age_days,
+        case when days_from_first_completed_order <= 7 
+            and customer_age_days >= 7 then 1 else 0 end as "repeat_1w_rate",
+        case when days_from_first_completed_order <= 14 
+            and customer_age_days >= 14 then 1 else 0 end as "repeat_2w_rate",
+        case when days_from_first_completed_order <= 28 
+            and customer_age_days >= 28 then 1 else 0 end as "repeat_4w_rate",
+        case when days_from_first_completed_order <= 56 
+            and customer_age_days >= 56 then 1 else 0 end as "repeat_8w_rate",
+        case when days_from_first_completed_order <= 84 
+            and customer_age_days >= 84 then 1 else 0 end as "repeat_12w_rate",
+        case when days_from_first_completed_order <= 168 
+            and customer_age_days >= 168 then 1 else 0 end as "repeat_24w_rate"
+    from {{ ref('orders_xf') }}
+    where order_seq_number = 2
+    order by customer_id, order_seq_number
+    
+), 
+
+cohort_sizes as (
+
+    select 
+      date_trunc(week,first_order_date) as cohort_week,
+      count(distinct customer_id) as cohort_size
+    from customers
+    group by 1
+    order by 1 desc
+
+)
+
+select 
+    s.cohort_week,
+    c.cohort_size,
+    sum("repeat_1w_rate")/c.cohort_size*100 as repeat_1w_rate,
+    sum("repeat_2w_rate")/c.cohort_size*100 as repeat_2w_rate,
+    sum("repeat_4w_rate")/c.cohort_size*100 as repeat_4w_rate,
+    sum("repeat_8w_rate")/c.cohort_size*100 as repeat_8w_rate,
+    sum("repeat_12w_rate")/c.cohort_size*100 as repeat_12w_rate,
+    sum("repeat_24w_rate")/c.cohort_size*100 as repeat_24w_rate
+from second s
+left join cohort_sizes c on c.cohort_week = s.cohort_week
+group by 1,2
+order by 1 asc


### PR DESCRIPTION
## This PR adds shopify financial models

The following models were created from queries used for the Perfect Keto Growth Model and updated to properly account for how Shopify calculates finances.