### PR TITLE
fix sku financial model reports

### DIFF
--- a/models/marts/financials/fct_shopify_sku_daily.sql
+++ b/models/marts/financials/fct_shopify_sku_daily.sql
@@ -61,8 +61,8 @@ final as (
         o.day,
         o.sku,
         o.gross_item_revenue,
-        o.gross_item_revenue-o.discounts+r.returns as net_item_revenue,
-        o.total_units-r.units_returned as total_units
+        o.gross_item_revenue-o.discounts+zeroifnull(r.returns) as net_item_revenue,
+        o.total_units-zeroifnull(r.units_returned) as total_units
     from orders_calc o
     left join refund_calc r on o.day = r.day and o.sku = r.sku
 

--- a/models/marts/financials/fct_shopify_sku_monthly.sql
+++ b/models/marts/financials/fct_shopify_sku_monthly.sql
@@ -61,8 +61,8 @@ final as (
         o.month,
         o.sku,
         o.gross_item_revenue,
-        o.gross_item_revenue-o.discounts+r.returns as net_item_revenue,
-        o.total_units-r.units_returned as total_units
+        o.gross_item_revenue-o.discounts+zeroifnull(r.returns) as net_item_revenue,
+        o.total_units-zeroifnull(r.units_returned) as total_units
     from orders_calc o
     left join refund_calc r on o.month = r.month and o.sku = r.sku
 

--- a/models/marts/financials/fct_shopify_sku_variant_monthly.sql
+++ b/models/marts/financials/fct_shopify_sku_variant_monthly.sql
@@ -66,8 +66,8 @@ final as (
         o.variant_title,
         o.sku,
         o.gross_item_revenue,
-        o.gross_item_revenue-o.discounts+r.returns as net_item_revenue,
-        o.total_units-r.units_returned as total_units
+        o.gross_item_revenue-o.discounts+zeroifnull(r.returns) as net_item_revenue,
+        o.total_units-zeroifnull(r.units_returned) as total_units
     from orders_calc o
     left join refund_calc r on o.month = r.month and o.variant_title = r.variant_title and o.sku = r.sku
 


### PR DESCRIPTION
## This PR fixes sku financial model report errors

In the initial sku financial commit, null fields were preventing certain calculations. This PR adds `zeroifnull` to fix those calculations.