### PR TITLE
fix order_item_id in refund_items model

### DIFF
--- a/models/staging/shopify/stg_shopify_refund_items.sql
+++ b/models/staging/shopify/stg_shopify_refund_items.sql
@@ -10,7 +10,7 @@ flattened as (
         refunds,
         f.value:id as refund_id,
         id as order_id,
-        f1.value:id as order_item_id,
+        f1.value:line_item:id as order_item_id,
         f1.value:line_item:title::string as product_title,
         f1.value:line_item:variant_title::string as variant_title,
         f1.value:line_item:sku::string as sku,


### PR DESCRIPTION
## This PR fixes the order_item_id field in the refund_items model

In the previous commit, the wrong id was referenced for order_item_id 