### PR TITLE
fix sales by channel in shopify financials

### DIFF
--- a/models/marts/financials/fct_shopify_daily.sql
+++ b/models/marts/financials/fct_shopify_daily.sql
@@ -89,6 +89,32 @@ refund_joined as (
 
 ),
 
+refund_channel1 as (
+
+    select 
+        r.*,
+        o.app_id 
+    from refund_joined r 
+    left join orders o on o.order_id = r.order_id  
+    
+),
+
+refund_channel2 as (
+
+    select
+        date_trunc(day,date) as day,
+        app_id,
+        sum(gross_returns) as gross_returns,
+        sum(discount_amount) as discount_returned,
+        sum(gross_returns)+sum(discount_amount) as net_returns,
+        sum(tax_amount) as tax_returned,
+        sum(shipping_amount) as shipping_returned,
+        sum(gross_returns)+sum(discount_amount)+sum(tax_amount)+sum(shipping_amount) as total_returns
+    from refund_channel1
+    group by 1,2
+
+),
+
 refund_final as (
 
     select
@@ -99,7 +125,7 @@ refund_final as (
         sum(tax_amount) as tax_returned,
         sum(shipping_amount) as shipping_returned,
         sum(gross_returns)+sum(discount_amount)+sum(tax_amount)+sum(shipping_amount) as total_returns
-    from refund_joined 
+    from refund_joined
     group by 1
     
 ),
@@ -129,35 +155,59 @@ quantity as (
     select 
         date_trunc(day,o.created_at) as day,
         sum(quantity) as total_units
-    from {{ ref('stg_shopify_orders') }} o 
-    join {{ ref('stg_shopify_order_items') }} oi on o.order_id = oi.order_id
+    from analytics.stg_shopify_orders o 
+    join analytics.stg_shopify_order_items oi on o.order_id = oi.order_id
     group by 1
 
 ),
 
 channels as (
+
     select 
         date_trunc(day,created_at) as order_day,
-        case when tags ilike '%wholesale%' then 'Wholesale'
-        when tags ilike '%subscription%' then 'Recharge'
-            else 'Online Store' end as channel,
+        app_id,
         sum(total_line_items_price) as order_gross,
         sum(total_discounts) as total_discounts,
         sum(total_shipping_cost) as order_shipping_gross,
-        sum(total_line_items_price) - sum(total_discounts) + sum(total_shipping_cost) as total_net
+        sum(total_tax) as order_tax_gross
     from orders 
     group by 1,2
     order by 1 desc, 6 desc
+    
 ),
 
 channels2 as (
+
+    select 
+        c.order_day,
+        case when c.app_id = 580111 then 'Online Store'
+            when c.app_id = 1150484 then 'Wholesale'
+            when c.app_id = 294517 then 'Recharge'
+            else 'Other' end as channel,
+        c.app_id,
+        order_gross,
+        total_discounts,
+        zeroifnull(gross_returns) as gross_returns,
+        order_shipping_gross,
+        zeroifnull(shipping_returned) as shipping_returned,
+        order_tax_gross,
+        zeroifnull(tax_returned) as tax_returned,
+        order_gross-total_discounts+zeroifnull(gross_returns)+order_shipping_gross+shipping_returned as total_net
+    from channels c 
+    left join refund_channel2 r on c.order_day = r.day and c.app_id = r.app_id
+
+),
+
+channels3 as (
+
     select 
         order_day,
         case when channel = 'Online Store' then total_net end as "Online Store Rev",
         case when channel = 'Recharge' then total_net end as "Recharge Rev",
         case when channel = 'Wholesale' then total_net end as "Wholesale Rev"
-    from channels
+    from channels2
     order by 1 desc
+    
 ),
 
 final as (
@@ -189,6 +239,6 @@ select
     sum(ch."Recharge Rev") as "Recharge Rev",
     sum(ch."Wholesale Rev") as "Wholesale Rev"
 from final f
-left join channels2 ch on f.day = ch.order_day
+left join channels3 ch on f.day = ch.order_day
 group by 1,2,3,4,5,6,7,8,9,10,11,12,13,14
 order by 1 asc


### PR DESCRIPTION
## This PR fixes sales by channel metrics in shopify financial models

Sales by channel columns for Online Store, Wholesale, and Recharge revenue columns were fixed in the following models:

- `fct_shopify_daily`
- `fct_shopify_monthly`

The prior revenue calculations were not properly accounting for returns and shipping returned amounts. 