### PR TITLE
fix financial model calculations

### DIFF
--- a/models/marts/financials/shopify/fct_shopify_sku_daily.sql
+++ b/models/marts/financials/shopify/fct_shopify_sku_daily.sql
@@ -22,7 +22,7 @@ refund_items as (
         order_item_price,
         order_item_subtotal,
         quantity,
-        order_item_price*quantity*-1 as gross_returns,
+        order_item_subtotal*-1 as gross_returns,
         discount_amount,
         tax_amount as tax_amount
     from {{ ref('stg_shopify_refund_items') }}

--- a/models/marts/financials/shopify/fct_shopify_sku_monthly.sql
+++ b/models/marts/financials/shopify/fct_shopify_sku_monthly.sql
@@ -22,7 +22,7 @@ refund_items as (
         order_item_price,
         order_item_subtotal,
         quantity,
-        order_item_price*quantity*-1 as gross_returns,
+        order_item_subtotal*-1 as gross_returns,
         discount_amount,
         tax_amount as tax_amount
     from {{ ref('stg_shopify_refund_items') }} 

--- a/models/marts/financials/shopify/fct_shopify_sku_variant_monthly.sql
+++ b/models/marts/financials/shopify/fct_shopify_sku_variant_monthly.sql
@@ -24,7 +24,7 @@ refund_items as (
         order_item_price,
         order_item_subtotal,
         quantity,
-        order_item_price*quantity*-1 as gross_returns,
+        order_item_subtotal*-1 as gross_returns,
         discount_amount,
         tax_amount as tax_amount
     from {{ ref('stg_shopify_refund_items') }}


### PR DESCRIPTION
## This PR fixes various financial model calculations

**fct_amazon_daily & fct_amazon_daily**

- Adds `order_gross` calculations for pending orders 

**fct_shopify_sku_daily & fct_shopify_sku_monthly & fct_shopify_sku_variant_monthly**

- Uses `order_item_subtotal*-1` for `gross_returns` instead of `order_item_price*quantity*-1`

**fct_shopify_weekly**

- Updates calculations from previous PR to `fct_shopify_daily` & `fct_shopify_monthly`