### PR TITLE
update wholesale order categorization

### DIFF
--- a/models/marts/financials/shopify/fct_shopify_daily.sql
+++ b/models/marts/financials/shopify/fct_shopify_daily.sql
@@ -10,7 +10,7 @@ orders as (
 
     select 
         o.*,
-        case when app_id = 1150484 then 'Wholesale'
+        case when tags ilike '%wholesale%' then 'Wholesale' 
             when app_id = 580111 then 'Online Store'
             when app_id = 294517 then 'Recharge'
             else 'Other' end as channel    

--- a/models/marts/financials/shopify/fct_shopify_monthly.sql
+++ b/models/marts/financials/shopify/fct_shopify_monthly.sql
@@ -10,7 +10,7 @@ orders as (
 
     select 
         o.*,
-        case when app_id = 1150484 then 'Wholesale'
+        case when tags ilike '%wholesale%' then 'Wholesale' 
             when app_id = 580111 then 'Online Store'
             when app_id = 294517 then 'Recharge'
             else 'Other' end as channel    

--- a/models/marts/financials/shopify/fct_shopify_weekly.sql
+++ b/models/marts/financials/shopify/fct_shopify_weekly.sql
@@ -10,7 +10,7 @@ orders as (
 
     select 
         o.*,
-        case when app_id = 1150484 then 'Wholesale'
+        case when tags ilike '%wholesale%' then 'Wholesale' 
             when app_id = 580111 then 'Online Store'
             when app_id = 294517 then 'Recharge'
             else 'Other' end as channel    


### PR DESCRIPTION
## This PR updates wholesale order categorization in financial models

Wholesale revenue calculated was under-represented in the Growth Model and in Shopify reports. An audit revealed that not all orders tagged with 'wholesale' were counted.

The categorization uses orders with tags containing 'wholesale' in the following models:

- fct_shopify_daily
- fct_shopify_weekly
- fct_shopify_monthly